### PR TITLE
make using widget tree more convenience.(fix conflict between KeyPress and Ctrl-KeyPress.)

### DIFF
--- a/pygubudesigner/main.py
+++ b/pygubudesigner/main.py
@@ -204,10 +204,14 @@ class PygubuUI(pygubu.TkApplication):
                 lambda e: self.tree_editor.cut_to_clipboard())
         self.tree_editor.treeview.bind('<KeyPress-Delete>',
                 lambda e: self.on_edit_menuitem_clicked('edit_item_delete'))
-        self.tree_editor.treeview.bind('<KeyPress-i>',
-                lambda e: self.tree_editor.treeview.event_generate('<Up>'))
-        self.tree_editor.treeview.bind('<KeyPress-k>',
-                lambda e: self.tree_editor.treeview.event_generate('<Down>'))
+        def clear_key_pressed(event, newevent):
+            # when KeyPress, not Ctrl-KeyPress, generate event.
+            if event.keysym_num == ord(event.char):
+                self.tree_editor.treeview.event_generate(newevent)
+        self.tree_editor.treeview.bind('<i>',
+                lambda e: clear_key_pressed(e, '<Up>'))
+        self.tree_editor.treeview.bind('<k>',
+                lambda e: clear_key_pressed(e, '<Down>'))
         #grid move bindings
         self.tree_editor.treeview.bind('<Alt-KeyPress-i>',
                 lambda e: self.on_edit_menuitem_clicked('grid_up'))


### PR DESCRIPTION
1> add hotkey on widget tree, i - select previous item, k - select next item. 
now, you can operate on widget tree only use I,J,K,L, Ctrl and Alt key.
use "event.keysym_num == ord(event.char)" to recognise KeyPress event or Ctrl-KeyPress event.
2> set focus at widget tree after add widget. 
you do not need click on widget tree befor use widget tree hotkey after add a widget.
