### PR TITLE
Fixed (type,name) ordering for tkvarentry.

### DIFF
--- a/pygubudesigner/widgets/tkvarentry.py
+++ b/pygubudesigner/widgets/tkvarentry.py
@@ -45,7 +45,7 @@ class TkVarPropertyEditor(PropertyEditor):
     def _get_value(self):
         value = ''
         if self._entry.value != '':
-            value = '{0}:{1}'.format(self._entry.value, self._cbox.value)
+            value = '{0}:{1}'.format(self._cbox.value, self._entry.value)
         return value
 
     def _set_value(self, value):


### PR DESCRIPTION
I was having issues with the type and the variable name getting mangled in the UI as well as when the xml was read back in by the builder.  

In the _get_value() method the ordering of the pair was parsed as (name, type) whereas in the _set_value() method as well as the builder it is (type, name).  I  changed it in the _get_value() method to minimize the number of files touched.
