### PR TITLE
Fix issue that causes file layouts to get mangled

### DIFF
--- a/pygubudesigner/uitreeeditor.py
+++ b/pygubudesigner/uitreeeditor.py
@@ -196,7 +196,7 @@ class WidgetsTreeEditor(object):
 
         return node
 
-    def _insert_item(self, root, data):
+    def _insert_item(self, root, data,from_file=False):
         """Insert a item on the treeview and fills columns from data"""
 
         tree = self.treeview
@@ -209,7 +209,7 @@ class WidgetsTreeEditor(object):
             # fix row position when using copy and paste
             # If collision, increase by 1
             row_count = self.get_max_row(root)
-            if row_count > int(row) and int(col) == 0:
+            if not from_file and (row_count > int(row) and int(col) == 0):
                 row = str(row_count + 1)
                 data.set_layout_property('row', row)
 
@@ -511,13 +511,13 @@ class WidgetsTreeEditor(object):
 
         self.previewer.resource_paths.append(os.path.dirname(filename))
         for element in eroot:
-            self.populate_tree('', eroot, element)
+            self.populate_tree('', eroot, element,from_file=True)
         children = self.treeview.get_children('')
         for child in children:
             self.draw_widget(child)
         self.previewer.show_selected(None, None)
 
-    def populate_tree(self, master, parent, element):
+    def populate_tree(self, master, parent, element,from_file=False):
         """Reads xml nodes and populates tree item"""
 
         data = WidgetDescr(None, None)
@@ -527,12 +527,12 @@ class WidgetsTreeEditor(object):
         data.set_property('id', uniqueid)
 
         if cname in builder.CLASS_MAP:
-            pwidget = self._insert_item(master, data)
+            pwidget = self._insert_item(master, data,from_file=from_file)
             xpath = "./child"
             children = element.findall(xpath)
             for child in children:
                 child_object = child.find('./object')
-                cwidget = self.populate_tree(pwidget, child, child_object)
+                cwidget = self.populate_tree(pwidget, child, child_object,from_file=from_file)
 
             return pwidget
         else:


### PR DESCRIPTION
I noticed the following issue. Suppose you create a layout, and then manually change the row values of items in column 0 using the menus. When you save the XML, the row values of the children are no longer in sequential order. When you reload this XML into designer, column 0 items can be moved from the original rows you set, with extra empty cells in rows above the items.
From this:
![good-ui-load-pygubu](https://cloud.githubusercontent.com/assets/82073/5500476/1f8fce02-8713-11e4-961c-7efef48872ba.png)

To this:
![bad-ui-load-pygubu](https://cloud.githubusercontent.com/assets/82073/5500484/35af9992-8713-11e4-96f3-a674f305ac6d.png)


The reason appears to be that as items are added, code in _insert_item makes new rows to accomodate new items. This works as long you are creating new items in the UI, but is not necessary when you are loading a pre-defined layout. The pull request is a minimal fix to this issue (I think). 

----
Added a "from_file" flag to populate_tree and _insert_item that
short-circuits the code that inserts new rows when a layout is
being loaded from xml.

From load_file, called populate_tree with from_file=True