### PR TITLE
Python 2 compatibility for the example in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ your aplication script as shown below:
 
 ```python
 #test.py
-import tkinter as tk
+try:
+    import tkinter as tk
+except:
+    import Tkinter as tk
 import pygubu
 
 


### PR DESCRIPTION
When the example in the readme is run under python 2.7 an error was raised, because the Tkinter module was renamed to tkinter.