### PR TITLE
Fix Windows batch file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ class CustomInstall(install):
             batfilename = 'pygubu-designer.bat'
             batpath = os.path.join(self.install_scripts, batfilename)
             with open(batpath, 'w') as batfile:
-                content = "{0} -m pygubudesigner".format(sys.executable)
+                content = '"{0}" -m pygubudesigner'.format(sys.executable)
                 batfile.write(content)
 
 

--- a/setup.py
+++ b/setup.py
@@ -44,7 +44,7 @@ class CustomInstall(install):
             batfilename = 'pygubu-designer.bat'
             batpath = os.path.join(self.install_scripts, batfilename)
             with open(batpath, 'w') as batfile:
-                content = '"{0}" -m pygubudesigner'.format(sys.executable)
+                content = '"{0}" -m pygubudesigner %1'.format(sys.executable)
                 batfile.write(content)
 
 


### PR DESCRIPTION
It crashes in paths with spaces like `c:\program files\python 3.5\python.exe -m pygubudesigner` returning `c:\program is not recognized as an internal or external command, operable program or batch file`.

Putting the path between quotes solves this.