### PR TITLE
"OrderedDict mutated during iteration" in file_new (Python 3.5)

### DIFF
--- a/pygubudesigner/previewer.py
+++ b/pygubudesigner/previewer.py
@@ -606,7 +606,7 @@ class PreviewHelper:
             self._sel_widget = None
 
     def remove_all(self):
-        for identifier in self.previews:
+        for identifier in list(self.previews):
             self.delete(identifier)
         self.resource_paths = []
 


### PR DESCRIPTION
In Python 3.5 OrderedDicts iterate over generators, not over lists, so when one tries to open a new file and the main window has previously loaded a project with more than one top level element (as in `pygubu-ui.ui`, which has two: `mainmenu` and `mainwindow`) it throws an exception and closes only the first element.
    
    C:\Users\Woden\Desktop>"c:\program files\python 3.5\python.exe" -m pygubudesigner
    python version: 3.5.0 on win32
    pygubu version: 0.9.7.9
    Exception in Tkinter callback
    Traceback (most recent call last):
        File "c:\program files\python 3.5\lib\tkinter\__init__.py", line 1549, in __call__
            return self.func(*args)
        File "c:\program files\python 3.5\lib\site-packages\pygubu\builder\tkstdwidgets.py", line 489, in item_callback
            callback(item_id)    
        File "c:\program files\python 3.5\lib\site-packages\pygubudesigner\main.py", line 426, in on_file_menuitem_clicked
            self.previewer.remove_all()
        File "c:\program files\python 3.5\lib\site-packages\pygubudesigner\previewer.py", line 609, in remove_all
            for identifier in self.previews:
    RuntimeError: OrderedDict mutated during iteration