### PR TITLE
Update __init__.py to solve logger module handlers problem

### DIFF
--- a/pygubu/builder/__init__.py
+++ b/pygubu/builder/__init__.py
@@ -33,7 +33,7 @@ from pygubu.stockimage import *
 import pygubu.builder.tkstdwidgets
 
 logger = logging.getLogger(__name__)
-
+logging.basicConfig()  # line added according to python documentation, to load standard Handlers of logging module
 
 def data_xmlnode_to_dict(element, translator=None):
     data = {}


### PR DESCRIPTION
In current version, calling pygubu routines according to examples, always get the error:
 - No handlers could be found for logger "pygubu.builder"
Reading Python documentation for module logger, this is due to handler not set and standard handlers not loaded by called methods.
So, the single line added (#36) load standard handlers and solve this problem.
Have tested on Python 2.7.13 (v2.7.13:a06454b1afa1, Dec 17 2016, 20:42:59) [MSC v.1500 32 bit (Intel)] on win32

By the way, congratulations on this project! I feel compelled to submit this fix because this project is very useful to me. Thank you!