### PR TITLE
Adds a Toplevel.preview hotkey for Issue #104

### DIFF
--- a/pygubudesigner/main.py
+++ b/pygubudesigner/main.py
@@ -590,7 +590,7 @@ class PygubuUI(pygubu.TkApplication):
         if itemid == 'preview_toplevel':
             self.tree_editor.preview_in_toplevel()
         if itemid == 'preview_toplevel_closeall':
-            eslf.previewer.close_toplevel_previews()
+            self.previewer.close_toplevel_previews()
 
     #Help menu
     def on_help_menuitem_clicked(self, itemid):

--- a/pygubudesigner/main.py
+++ b/pygubudesigner/main.py
@@ -214,6 +214,9 @@ class PygubuUI(pygubu.TkApplication):
         master.bind_all(
             '<Control-KeyPress-k>',
             lambda e: self.on_edit_menuitem_clicked('edit_item_down'))
+        master.bind_all(
+            '<F5>',
+            lambda e: self.tree_editor.preview_in_toplevel())
 
         #
         # Widget bindings

--- a/pygubudesigner/main.py
+++ b/pygubudesigner/main.py
@@ -217,6 +217,9 @@ class PygubuUI(pygubu.TkApplication):
         master.bind_all(
             '<F5>',
             lambda e: self.tree_editor.preview_in_toplevel())
+        master.bind_all(
+            '<F6>',
+            lambda e: self.previewer.close_toplevel_previews())
 
         #
         # Widget bindings
@@ -587,7 +590,7 @@ class PygubuUI(pygubu.TkApplication):
         if itemid == 'preview_toplevel':
             self.tree_editor.preview_in_toplevel()
         if itemid == 'preview_toplevel_closeall':
-            self.previewer.close_toplevel_previews()
+            eslf.previewer.close_toplevel_previews()
 
     #Help menu
     def on_help_menuitem_clicked(self, itemid):

--- a/pygubudesigner/preferences.py
+++ b/pygubudesigner/preferences.py
@@ -52,14 +52,13 @@ def load_configfile():
     for k in options:
         defaults[k] = options[k]['default']
     if sys.version_info < (3,0):
-        print "Python 2"
         #Python 2.7
+        keys = defaults.keys()
         for i in range(0, len(defaults)):
-            config.set(SEC_GENERAL, defaults.keys()[i], defaults.values()[i]) # Dirty Python 2 workaround, FIXME
+            config.set(SEC_GENERAL, keys[i], defaults.get(keys[i]))
     else:
-        print "Python 3"
         #Python 3
-        # config[SEC_GENERAL] = defaults
+        config[SEC_GENERAL] = defaults
     if not os.path.exists(CONFIG_FILE):
         initialize_configfile()
     else:

--- a/pygubudesigner/preferences.py
+++ b/pygubudesigner/preferences.py
@@ -1,5 +1,6 @@
 # encoding: utf-8
 import os
+import sys
 try:
     import tkinter as tk
     from tkinter import ttk
@@ -50,8 +51,15 @@ def load_configfile():
     defaults = {}
     for k in options:
         defaults[k] = options[k]['default']
-    config[SEC_GENERAL] = defaults
-    
+    if sys.version_info < (3,0):
+        print "Python 2"
+        #Python 2.7
+        for i in range(0, len(defaults)):
+            config.set(SEC_GENERAL, defaults.keys()[i], defaults.values()[i]) # Dirty Python 2 workaround, FIXME
+    else:
+        print "Python 3"
+        #Python 3
+        # config[SEC_GENERAL] = defaults
     if not os.path.exists(CONFIG_FILE):
         initialize_configfile()
     else:

--- a/pygubudesigner/ui/pygubu-ui.ui
+++ b/pygubudesigner/ui/pygubu-ui.ui
@@ -169,7 +169,7 @@
         <property name="underline">0</property>
         <child>
           <object class="tk.Menuitem.Command" id="preview_toplevel">
-			<property name="accelerator">F5</property>
+			      <property name="accelerator">F5</property>
             <property name="command">on_previewmenu_action</property>
             <property name="command_id_arg">True</property>
             <property name="label" translatable="yes">Preview in Toplevel</property>
@@ -177,6 +177,7 @@
         </child>
         <child>
           <object class="tk.Menuitem.Command" id="preview_toplevel_closeall">
+            <property name="accelerator">F6</property>
             <property name="command">on_previewmenu_action</property>
             <property name="command_id_arg">True</property>
             <property name="label" translatable="yes">Close Toplevel previews</property>

--- a/pygubudesigner/ui/pygubu-ui.ui
+++ b/pygubudesigner/ui/pygubu-ui.ui
@@ -169,6 +169,7 @@
         <property name="underline">0</property>
         <child>
           <object class="tk.Menuitem.Command" id="preview_toplevel">
+			<property name="accelerator">F5</property>
             <property name="command">on_previewmenu_action</property>
             <property name="command_id_arg">True</property>
             <property name="label" translatable="yes">Preview in Toplevel</property>


### PR DESCRIPTION
- Adds a hotkey for opening Toplevel previews (F5)
- Adds a hotkey for closing opened previews (F6)
- Fixes a Python 2 issue where the application wouldn't startup, and would fail when loading the config file (preferences.py)

Tested on Windows (2.7) and on Ubuntu (3.6)