### PR TITLE
Make Tooltips more readable

### DIFF
--- a/pygubu/widgets/simpletooltip.py
+++ b/pygubu/widgets/simpletooltip.py
@@ -36,7 +36,8 @@ class ToolTip(object):
         except tk.TclError:
             pass
         label = tk.Label(tw, text=self.text, justify=tk.LEFT,
-                      background="#ffffe0", relief=tk.SOLID, borderwidth=1,
+                      background="#ffffe0", foreground="black",
+                      relief=tk.SOLID, borderwidth=1,
                       font=("tahoma", "8", "normal"))
         label.pack(ipadx=1)
 


### PR DESCRIPTION
When I installed this on my computer, the tooltips looked like this:
![gray_tooltip](https://user-images.githubusercontent.com/34218082/44435163-a7877400-a57c-11e8-9b96-3d91202e6894.png)
which is barely readable.

After adding `foreground="black"` to the label, it looks like this:
![black_tooltip](https://user-images.githubusercontent.com/34218082/44435178-c259e880-a57c-11e8-9157-061bcfccef02.png)
which I think is much better.