### PR TITLE
Fix missing imports and invalid variable names

### DIFF
--- a/pygubu/widgets/editabletreeview.py
+++ b/pygubu/widgets/editabletreeview.py
@@ -29,7 +29,7 @@ except:
 
 class EditableTreeview(ttk.Treeview):
     """A simple editable treeview
-    
+
     It uses the following events from Treeview:
         <<TreviewSelect>>
         <4>
@@ -42,7 +42,7 @@ class EditableTreeview(ttk.Treeview):
         <ButtonRelease-1>
         <Motion>
     If you need them use add=True when calling bind method.
-    
+
     It Generates two virtual events:
         <<TreeviewInplaceEdit>>
         <<TreeviewCellEdited>>
@@ -80,17 +80,17 @@ class EditableTreeview(ttk.Treeview):
         r = event.widget.identify_region(event.x, event.y)
         if r in ('separator', 'header'):
             self._header_clicked = True
-    
+
     def __on_mouse_motion(self, event):
         if self._header_clicked:
             self._header_dragged = True
-    
+
     def __on_button1_release(self, event):
         if self._header_dragged:
             self.after_idle(self.__updateWnds)
         self._header_clicked = False
         self._header_dragged = False
-    
+
     def __on_key_press(self, key, event):
         if key == 'Home':
             self.selection_set("")
@@ -272,7 +272,7 @@ class EditableTreeview(ttk.Treeview):
                 textvariable=svar, from_=min, to=max, increment=step)
         sb = self._inplace_widgets[col]
         sb.bind('<Unmap>', lambda e: self.__update_value(col, item))
-        cb.bind('<FocusOut>', lambda e: self.__update_value(col, item))
+        sb.bind('<FocusOut>', lambda e: self.__update_value(col, item))
         self._inplace_widgets_show[col] = True
 
 

--- a/pygubu/widgets/tkscrollbarhelper.py
+++ b/pygubu/widgets/tkscrollbarhelper.py
@@ -23,6 +23,7 @@ try:
 except:
     import Tkinter as tk
 from pygubu import ApplicationLevelBindManager as BindManager
+from pygubu.binding import remove_binding
 
 
 logger = logging.getLogger(__name__)
@@ -88,7 +89,7 @@ def ScrollbarHelperFactory(frame_class, scrollbar_class):
                     msg = "widget {} has no attribute 'xview'".format(str(cwidget))
                     logger.info(msg)
             self._configure_mousewheel()
-        
+
         def configure(self, cnf=None, **kw):
             args = tk._cnfmerge((cnf, kw))
             key = 'usemousewheel'
@@ -107,7 +108,7 @@ def ScrollbarHelperFactory(frame_class, scrollbar_class):
             return frame_class.cget(self, key)
 
         __getitem__ = cget
-        
+
         def _configure_mousewheel(self):
             cwidget = self.cwidget
             if self.usemousewheel:

--- a/pygubu/widgets/tkscrolledframe.py
+++ b/pygubu/widgets/tkscrolledframe.py
@@ -23,6 +23,7 @@ try:
 except:
     import Tkinter as tk
 from pygubu import ApplicationLevelBindManager as BindManager
+from pygubu.binding import remove_binding
 
 
 def ScrolledFrameFactory(frame_class, scrollbar_class):
@@ -35,7 +36,7 @@ def ScrolledFrameFactory(frame_class, scrollbar_class):
             self.scrolltype = kw.pop('scrolltype', self.VERTICAL)
             self.usemousewheel = tk.getboolean(kw.pop('usemousewheel', False))
             self._bindingids = []
-            
+
             super(ScrolledFrame, self).__init__(master, **kw)
 
             self._clipper = frame_class(self, width=200, height=200)
@@ -168,7 +169,7 @@ def ScrolledFrameFactory(frame_class, scrollbar_class):
                 relheight = 1
             else:
                 # The scrolled frame is larger than the clipping window.
-                # use expand by default 
+                # use expand by default
                 if self._startY + clipperHeight > frameHeight:
                     self._startY = frameHeight - clipperHeight
                     endScrollY = 1.0
@@ -249,7 +250,7 @@ def ScrolledFrameFactory(frame_class, scrollbar_class):
             else:
                 self.vsb.grid_forget()
                 #interior.grid_columnconfigure(3, minsize = 0)
-        
+
         def configure(self, cnf=None, **kw):
             args = tk._cnfmerge((cnf, kw))
             key = 'usemousewheel'
@@ -268,7 +269,7 @@ def ScrolledFrameFactory(frame_class, scrollbar_class):
             return frame_class.cget(self, key)
 
         __getitem__ = cget
-                
+
         def _configure_mousewheel(self):
             if self.usemousewheel:
                 BindManager.init_mousewheel_binding(self)


### PR DESCRIPTION
1. Fix invalid variable name in `editabletreeview.py` (cb -> sb)
2. Add missing import of `remove_binding` function to `tkscrollbarhelper.py` and `tkscrolledframe.py`

Some trailing spaces were removed by my text editor, it should be safe to merge.