### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/pygubu/stockimage.py
+++ b/pygubu/stockimage.py
@@ -116,7 +116,7 @@ When image is used, the class maintains it on memory for tkinter"""
         :param str prefix: Additionaly a prefix for the key can be provided,
             so the resulting key will be prefix + filename
         :param iterable ext: list of file extensions to load. Defaults to
-            tk suported image extensions. Example ('.jpg', '.png')
+            tk supported image extensions. Example ('.jpg', '.png')
         """
 
         for filename in os.listdir(dir_path):

--- a/pygubu/widgets/calendarframe.py
+++ b/pygubu/widgets/calendarframe.py
@@ -87,7 +87,7 @@ class CalendarFrame(ttk.Frame):
             'markbg': 'white',
             'markfg': 'blue',
         }
-        # remove custom options from kw before initializating ttk.Frame
+        # remove custom options from kw before initialization ttk.Frame
         for k, v in options.items():
             options[k] = kw.pop(k, v)
 

--- a/pygubu/widgets/combobox.py
+++ b/pygubu/widgets/combobox.py
@@ -23,7 +23,7 @@ class Combobox(ttk.Combobox, object):
             'keyvariable': None,
             'textvariable': None,
         }
-        # remove custom options from kw before initializating
+        # remove custom options from kw before initialization
         for k, v in options.items():
             options[k] = kw.pop(k, v)
         


### PR DESCRIPTION
There are small typos in:
- pygubu/stockimage.py
- pygubu/widgets/calendarframe.py
- pygubu/widgets/combobox.py

Fixes:
- Should read `initialization` rather than `initializating`.
- Should read `supported` rather than `suported`.

Closes #244