### PR TITLE
Remove redundant gridrc properties.

### DIFF
--- a/pygubu/builder/widgetmeta.py
+++ b/pygubu/builder/widgetmeta.py
@@ -77,11 +77,27 @@ class WidgetMeta(object):
                 index = i
                 break
         if index is None:
+            # We're setting the grid rc property on this widget for the first time.
+            
             line = GridRCLine(rctype, rcid, pname, value)
             self.gridrc_properties.append(line)
         else:
-            line = GridRCLine(rctype, rcid, pname, value)
-            self.gridrc_properties[index] = line
+            # We're updating an existing grid rc property value.
+
+            # Prevent code such as weight='0', uniform='' from showing up 
+            # in the generated code - it would be redundant.
+            if (pname in ('minsize', 'pad', 'weight') and value == '0') \
+               or (pname == 'uniform' and not value):
+                
+                # We found a redundant value 
+                # '0' or a blank string if it's for the property: uniform
+                
+                # Remove the gridrc property
+                self.gridrc_properties.pop(index)
+            else:
+                # Update the gridrc property
+                line = GridRCLine(rctype, rcid, pname, value)
+                self.gridrc_properties[index] = line
 
     def __repr__(self):
         tpl = '''<WidgetMeta classname: {0} identifier: {1}>'''


### PR DESCRIPTION
In this pull request, gridrc properties such as weight='0', are removed automatically.

**Current Problem:**
Redundant code is generated for grid rc properties if they have a value of '0' or a blank string.
To reproduce this problem, follow these steps:
1. Change the weight of any widget to 1
2. Change it back to 0
3. Generate the code and you will see that it will generate `weight='0'`, but it's not needed at all.

The problem applies to:
_minsize, pad, weight, uniform_

**Proposed Solution:**
If the gridrc value of a widget changes to a zero (for **minsize**, **pad**, **weight**), remove the gridrc setting completely, because it's not needed if the value is zero.

If the **uniform** value is a blank string, remove the property completely, because it's not needed if the value is a blank string.
![gridrc_before](https://user-images.githubusercontent.com/45316730/143627308-46b8f873-2293-448e-ae4e-ba765c6c240c.png)
![gridrc_after](https://user-images.githubusercontent.com/45316730/143627315-61a8bedf-445e-46b2-a8f5-a58aeadadafb.png)

