### PR TITLE
Generate regular treeview properties in the Code Script

### DIFF
--- a/pygubu/builder/ttkstdwidgets.py
+++ b/pygubu/builder/ttkstdwidgets.py
@@ -445,6 +445,12 @@ class TTKTreeviewBO(TTKWidgetBO):
                 kwargs = ",".join(bag)
                 line = "{0}.heading('{1}', {2})".format(targetid, col, kwargs)
                 lines.append(line)
+
+        # Get other treeview properties such as padding, cursor, selectmode, etc.
+        treeview_properties = super().code_configure(targetid)
+        for treeview_property in treeview_properties:
+            lines.append(treeview_property)
+
         return lines
 
 


### PR DESCRIPTION
Fixed bug that prevents regular Treeview properties (and EditableTreeview) from getting code generated in the 'Code Script' tab (for example: padding, selectmode, etc).

How to reproduce the bug:
1) Add a treeview widget in Pygubu Designer
2) Set the 'padding' property and the 'selectmode' property
3) Generate the Code Script
4) It won't generate the code for padding and selectmode.

![before1](https://user-images.githubusercontent.com/45316730/179617636-73c0e3f5-c9a6-4fee-ada9-f426828574f3.png)

![before2](https://user-images.githubusercontent.com/45316730/179617664-83025c74-c5be-4596-b6d2-d7d5dec0df6e.png)

![after](https://user-images.githubusercontent.com/45316730/179617747-96666ff8-cf51-4df8-958d-126d50762f33.png)


