### PR TITLE
Add PyInstaller hook

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ tkcalendar = ['tkcalendar']
 awesometkinter = ['AwesomeTkinter']
 all = ['AwesomeTkinter', 'tkintertable', 'tksheet', 'ttkwidgets', 'tkinterweb', 'tkcalendar']
 
+[project.entry-points."pyinstaller40"]
+hook-dirs = "pygubu.__pyinstaller:get_hook_dirs"
+
 [tool.setuptools.dynamic]
 version = {attr = "pygubu.__version__"}
 

--- a/src/pygubu/__pyinstaller/__init__.py
+++ b/src/pygubu/__pyinstaller/__init__.py
@@ -1,0 +1,5 @@
+import os
+
+
+def get_hook_dirs() -> list[str]:
+    return [os.path.dirname(__file__)]

--- a/src/pygubu/__pyinstaller/hook-pygubu.py
+++ b/src/pygubu/__pyinstaller/hook-pygubu.py
@@ -1,0 +1,11 @@
+hiddenimports = [
+    'pygubu.plugins.tk.tkstdwidgets',
+    'pygubu.plugins.ttk.ttkstdwidgets',
+    'pygubu.plugins.pygubu.dialog',
+    'pygubu.plugins.pygubu.editabletreeview',
+    'pygubu.plugins.pygubu.scrollbarhelper',
+    'pygubu.plugins.pygubu.scrolledframe',
+    'pygubu.plugins.pygubu.tkscrollbarhelper',
+    'pygubu.plugins.pygubu.tkscrolledframe',
+    'pygubu.plugins.pygubu.pathchooserinput',
+]


### PR DESCRIPTION
The imports for the optional plugins could also be added.
I don't believe that they take up much more space, but this makes pygubu work out of the box with pyinstaller.