### PR TITLE
fix for missed update of 'activeoutline' color

### DIFF
--- a/src/pygubu/plugins/pygubu/calendarframe.py
+++ b/src/pygubu/plugins/pygubu/calendarframe.py
@@ -60,9 +60,8 @@ register_custom_property(
     _builder_id,
     "month",
     "choice",
-    values=("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"),
+    values=("", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"),
     state="readonly",
-    default_value="1",
 )
 register_custom_property(_builder_id, "calendarfg", "colorentry")
 register_custom_property(_builder_id, "calendarbg", "colorentry")

--- a/src/pygubu/widgets/calendarframe.py
+++ b/src/pygubu/widgets/calendarframe.py
@@ -461,7 +461,7 @@ class CalendarFrame(ttk.Frame):
             if redraw:
                 rec = self._recmat[i]
                 canvas.coords(rec, x, y, x1, y1)
-                canvas.itemconfigure(rec, fill=options["calendarbg"])
+                canvas.itemconfigure(rec, fill=options["calendarbg"], activeoutline=options["selectbg"])
             else:
                 rec = canvas.create_rectangle(
                     x,


### PR DESCRIPTION
The widget calls a draw during init which causes the `activeoutline` color to remain at the default. This change corrects that to later use whatever color was set later with `.configure()`.

While at it did I also remove the 'forcing' to choose a month for the widget in the designer, I found that one odd to begin with.