### PR TITLE
widget parameter to set linewidth in canvas

### DIFF
--- a/src/pygubu/plugins/pygubu/calendarframe.py
+++ b/src/pygubu/plugins/pygubu/calendarframe.py
@@ -26,6 +26,7 @@ class CalendarFrameBuilder(BuilderObject):
         "state",
         "markbg",
         "markfg",
+        "linewidth",
     )
     ro_properties = TTKFrame.ro_properties
     properties = OPTIONS_STANDARD + OPTIONS_SPECIFIC + OPTIONS_CUSTOM
@@ -62,6 +63,14 @@ register_custom_property(
     "choice",
     values=("", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"),
     state="readonly",
+)
+register_custom_property(
+    _builder_id,
+    "linewidth",
+    "choice",
+    values=("1", "2", "3", "4"),
+    state="readonly",
+    default_value="1",
 )
 register_custom_property(_builder_id, "calendarfg", "colorentry")
 register_custom_property(_builder_id, "calendarbg", "colorentry")


### PR DESCRIPTION
This change is intended to make the cell border better visible. I've tested the `linewidth` setting from 1 to 4 and made the needed changes so it looks good with all those different widths.

I've also done minor changes to the default colors so they also offer better viewability. The old default for "marked" with blue text on white background was near invisible to normal black text on white.

Another change is also to use different border colors for certain cases to offer more visual information, for example using the "marked" cell border for a "selected" day (unless it's also hovered) so it's visible that it's both, selected *and* marked.

This what this looks like with the default settings:
The 26th is "today", the 2nd is "selected" and "marked", the 3rd is just "marked" and the cursor shows the default hovering cellborder.
![image](https://github.com/alejandroautalan/pygubu/assets/1014362/525940cd-f5fd-4d7a-82fd-374f0523e61f)
