### PR TITLE
Set widget identifier as name if given

### DIFF
--- a/src/pygubu/builder.py
+++ b/src/pygubu/builder.py
@@ -210,6 +210,12 @@ class Builder(object):
         if not self.is_mapped(wmeta.classname):
             self._import_class(wmeta.classname)
 
+        if wmeta.is_named:
+            if not extra_init_args:
+                extra_init_args = { "name": wmeta.identifier }
+            if "name" not in extra_init_args:
+                extra_init_args["name"] = wmeta.identifier
+
         if self.is_mapped(wmeta.classname):
             bclass = self._get_builder_for(wmeta.classname)
             parent = bclass.factory(self, wmeta)


### PR DESCRIPTION
This is a small change so that custom set widget id's actually get used in the creation process of widgets.
It's what I came up with regarding https://github.com/alejandroautalan/pygubu-designer/discussions/212

This is what it looks like in the code:
![image](https://github.com/alejandroautalan/pygubu/assets/1014362/85c5ae54-af42-47b0-98bb-c571e6df8a73)
`.activity` refers to a named `tk.Frame` in the mainwindow
`.frm_task_8` is another `tk.Frame` placed in the frame `activity`
`.lbl_from` is a named `tk.Label` inside `frm_task_8`

To me, this way of using the widget names we can assign in the designer make actually sense, instead of the plain `!<classname><#n>`.
It will still do this by default, but now custom names are actually used.

Not sure if it might be better to also prefix the names with a special character, just a different one than the default `!`, but for that I understand Tkinter's / Pygubu's `.nametowidget()` workings too little.